### PR TITLE
Constraints for Serializer and Communicators

### DIFF
--- a/Networking/CommunicationFactory.cs
+++ b/Networking/CommunicationFactory.cs
@@ -5,8 +5,8 @@ namespace Networking
     public static class CommunicationFactory
     {
         // Communicator Instance
-        private static readonly Lazy<ICommunicator> _clientCommunicator = new(() => new ClientCommunicator());
-        private static readonly Lazy<ICommunicator> _serverCommunicator = new(() => new ServerCommunicator());
+        private static readonly Lazy<ICommunicator> SClientCommunicator = new(() => new ClientCommunicator());
+        private static readonly Lazy<ICommunicator> SServerCommunicator = new(() => new ServerCommunicator());
         /// <summary>
         /// Returns the Communicator instance that is running.
         /// In test mode, It always returns a new instance.
@@ -15,8 +15,8 @@ namespace Networking
         public static ICommunicator GetCommunicator(bool isClient = true, bool isTesting = false)
         {
             if (isClient)
-                return isTesting ? new ClientCommunicator() : _clientCommunicator.Value;
-            return isTesting ? new ServerCommunicator() : _serverCommunicator.Value;
+                return isTesting ? new ClientCommunicator() : SClientCommunicator.Value;
+            return isTesting ? new ServerCommunicator() : SServerCommunicator.Value;
         }
     }
 }

--- a/Networking/CommunicationManager/ClientCommunicator.cs
+++ b/Networking/CommunicationManager/ClientCommunicator.cs
@@ -6,7 +6,7 @@ using System.Net;
 
 namespace Networking
 {
-    public class ClientCommunicator : ICommunicator
+    internal class ClientCommunicator : ICommunicator
     {
         private readonly Dictionary<string, INotificationHandler> _subscribedModules = new();
 

--- a/Networking/CommunicationManager/ServerCommunicator.cs
+++ b/Networking/CommunicationManager/ServerCommunicator.cs
@@ -5,14 +5,9 @@ using System.Collections.Generic;
 using System.Net;
 using System.Diagnostics;
 
-/// <summary>
-/// This file contains the class Server which will be running on the server.
-/// and accepts client request.
-/// </summary>
-/// <author>Tausif Iqbal </author>
 namespace Networking
 {
-    public class ServerCommunicator : ICommunicator
+    internal class ServerCommunicator : ICommunicator
     {
         /** Declare sendSocketListenerServer variable for sending messages across the network*/
         private SendSocketListenerServer _sendSocketListenerServer;

--- a/Networking/QueueManagement/ReceiveQueueListener.cs
+++ b/Networking/QueueManagement/ReceiveQueueListener.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -42,7 +41,7 @@ namespace Networking
         /// <summary>
         /// Listens on the receiving queue and calls Notification Handler of the corresponding module.
         /// </summary>
-        public void ListenQueue()
+        private void ListenQueue()
         {
             while (_listenRun)
             {

--- a/Networking/Serializer/ISerializer.cs
+++ b/Networking/Serializer/ISerializer.cs
@@ -8,13 +8,13 @@
         /// <typeparam name="T">Object Type.</typeparam>
         /// <param name="objectToSerialize">Object to serialize.</param>
         /// <returns>Serialized XML string.</returns>
-        string Serialize<T>(T objectToSerialize);
+        string Serialize<T>(T objectToSerialize) where T: new();
 
         /// <summary>
         /// Returns the type of object serialized as the XML string.
         /// </summary>
         /// <param name="serializedString">Serialized XML string.</param>
-        /// <param name="nameSpace">Namespace of the module deserializng the string.</param>
+        /// <param name="nameSpace">Namespace of the module deserializing the string.</param>
         /// <returns>Object Type.</returns>
         string GetObjectType(string serializedString, string nameSpace);
 

--- a/Networking/Serializer/Serializer.cs
+++ b/Networking/Serializer/Serializer.cs
@@ -14,11 +14,9 @@ namespace Networking
             try
             {
                 XmlSerializer serializer = new XmlSerializer(objectToSerialize.GetType());
-                using (var stringStream = new StringWriter())
-                {
-                    serializer.Serialize(stringStream, objectToSerialize);
-                    return stringStream.ToString();
-                }
+                using var stringStream = new StringWriter();
+                serializer.Serialize(stringStream, objectToSerialize);
+                return stringStream.ToString();
             }
             catch (Exception ex)
             {
@@ -47,8 +45,8 @@ namespace Networking
             try
             {
                 XmlSerializer serializer = new XmlSerializer(typeof(T));
-                using (StringReader stringReader = new StringReader(serializedString))
-                    return (T)serializer.Deserialize(stringReader);
+                using StringReader stringReader = new StringReader(serializedString);
+                return (T)serializer.Deserialize(stringReader);
             }
             catch (Exception ex)
             {

--- a/Networking/SocketManager/ReceiveSocketListener.cs
+++ b/Networking/SocketManager/ReceiveSocketListener.cs
@@ -89,7 +89,7 @@ namespace Networking
                     {
                         byte[] inStream = new byte[Threshold];
                         networkStream.Read(inStream, 0, inStream.Length);
-                        string buffer = System.Text.Encoding.ASCII.GetString(inStream);
+                        string buffer = Encoding.ASCII.GetString(inStream);
                         for (int i = 0; i < Threshold; i++)
                         {
                             if (buffer[i]!='\u0000')

--- a/Networking/SocketManager/SendSocketListenerServer.cs
+++ b/Networking/SocketManager/SendSocketListenerServer.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Net.Sockets;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace Networking
 {
@@ -14,7 +12,7 @@ namespace Networking
         private readonly IQueue _queue;
 
         // Declare the dictionary variable which stores client_ID and corresponding socket object 
-        private readonly Dictionary<string, TcpClient> _clientIdSocket = new();
+        private readonly Dictionary<string, TcpClient> _clientIdSocket;
 
         // Declare the thread variable of SendSocketListenerServer 
         private Thread _listen;

--- a/Testing/Networking/CommunicationFactoryTesting.cs
+++ b/Testing/Networking/CommunicationFactoryTesting.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Networking;
-using AutoFixture;
-using FluentAssertions;
-using Testing.Networking.Objects;
 
 namespace Testing.Networking
 {
@@ -11,7 +7,7 @@ namespace Testing.Networking
     class CommunicationFactoryTesting
     {
         [Test]
-        public void singleton()
+        public void GetCommunicator_MustReturnReferenceToSameObject()
         {
             ICommunicator comm1 = CommunicationFactory.GetCommunicator();
             ICommunicator comm2 = CommunicationFactory.GetCommunicator();

--- a/Testing/Networking/Serialization/Objects.cs
+++ b/Testing/Networking/Serialization/Objects.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Testing.Networking.Objects
+﻿namespace Testing.Networking.Objects
 {
     public class SimpleObject
     {

--- a/Testing/Networking/Serialization/SerializerTesting.cs
+++ b/Testing/Networking/Serialization/SerializerTesting.cs
@@ -15,7 +15,6 @@ namespace Testing.Networking
         public void SetUp()
         {
             _ser = new Serializer();
-            var random = TestContext.CurrentContext.Random;
         }
         [Test]
         public void SerializeDeserializeSimpleObject()
@@ -71,8 +70,8 @@ namespace Testing.Networking
             // Serialize
             SimpleObject serObj = new Fixture().Create<SimpleObject>();
             string xml = _ser.Serialize(serObj);
-            // Corupt xml string
-            xml = xml.Substring(50);
+            // Corrupt xml string
+            xml = xml[50..];
             Assert.Throws<InvalidOperationException>(() => _ser.Deserialize<SimpleObject>(xml));
         }
     }

--- a/Testing/Networking/SocketManagement/CommunicatorTesting.cs
+++ b/Testing/Networking/SocketManagement/CommunicatorTesting.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Networking;
 using NUnit.Framework;
 
@@ -8,7 +7,7 @@ namespace Testing.Networking.SocketManagement
     public class CommunicatorTesting
     {
         [Test, Category("pass")]
-        public void Server_and_Client_StartTest()
+        public void Start_ClientServerStartup_StartupMustPass()
         {
             // start the server
             ICommunicator server = CommunicationFactory.GetCommunicator(false, true);

--- a/Testing/Networking/SocketManagement/ReceiveSocketListenerTesting.cs
+++ b/Testing/Networking/SocketManagement/ReceiveSocketListenerTesting.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -16,8 +15,6 @@ namespace Testing.Networking.SocketManagement
         private IQueue _queue;
         private Machine _server;
         private ReceiveSocketListener _receiveSocketListener;
-        private const int Threshold = 1025;
-        private string Message => NetworkingGlobals.GetRandomString();
         private TcpClient _serverSocket;
         private TcpClient _clientSocket;
         

--- a/Testing/Networking/SocketManagement/SendSocketListenerClientTesting.cs
+++ b/Testing/Networking/SocketManagement/SendSocketListenerClientTesting.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Networking;
@@ -18,19 +16,8 @@ namespace Testing.Networking.SocketManagement
         private Machine _server;
         private SendSocketListenerClient _sendSocketListenerClient;
         private ReceiveSocketListener _receiveSocketListener;
-        private const int Threshold = 1025;
-        private string Message => NetworkingGlobals.GetRandomString();
         private TcpClient _serverSocket;
         private TcpClient _clientSocket;
-        
-        private string GetMessage(Packet packet)
-        {
-            string msg = packet.ModuleIdentifier;
-            msg += ":";
-            msg += packet.SerializedData;
-            msg += "EOF";
-            return msg;
-        }
 
         [SetUp]
         public void StartSendSocketListenerClient()

--- a/Testing/Networking/SocketManagement/SendSocketListenerServerTesting.cs
+++ b/Testing/Networking/SocketManagement/SendSocketListenerServerTesting.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Networking;
 using NUnit.Framework;


### PR DESCRIPTION
- This PR ensures that modules can use the networking module only through the CommunicationFactory
- This also forces every module to add a parameterless constructor (if they don't have one)