### PR TITLE
Reply feature added in content module

### DIFF
--- a/Content/Client/ChatClient.cs
+++ b/Content/Client/ChatClient.cs
@@ -55,6 +55,7 @@ namespace Content
             Converted.ReplyThreadId = toconvert.ReplyThreadId;
             Converted.Starred = false;
             Converted.SentTime = DateTime.Now;
+			Converted.ReplyMsgId = toconvert.ReplyMsgId;
 			Trace.WriteLine("[ChatClient Converting SendMessageData object to a MessageData object");
             return Converted;
         }

--- a/Content/Client/ContentClientNotificationHandler.cs
+++ b/Content/Client/ContentClientNotificationHandler.cs
@@ -34,7 +34,7 @@ namespace Content
             Trace.WriteLine("[ContentClientNotificationHandler] Deserializing data received from network");
             string deserializedType = _serializer.GetObjectType(data, "Content");
 
-            if (string.Equals(deserializedType,"Content.MessageData"))
+            if (string.Equals(deserializedType,typeof(MessageData).ToString()))
             {
                 _receivedMessage = _serializer.Deserialize<MessageData>(data);
                 _contentHandler.OnReceive(_receivedMessage);

--- a/Content/Client/ContentClientNotificationHandler.cs
+++ b/Content/Client/ContentClientNotificationHandler.cs
@@ -40,7 +40,7 @@ namespace Content
                 _contentHandler.OnReceive(_receivedMessage);
             }
 
-            else if (string.Equals(deserializedType, "Content.ArrayOfChatContext"))
+            else if (string.Equals(deserializedType, typeof(List<ChatContext>).ToString()))
             {
                 _allMessages = _serializer.Deserialize<List<ChatContext>>(data);
                 _contentHandler.OnReceive(_allMessages);

--- a/Content/Models/ReceiveMessageData.cs
+++ b/Content/Models/ReceiveMessageData.cs
@@ -50,6 +50,8 @@ namespace Content
         /// </summary>
         public MessageType Type;
 
+        public int ReplyMsgId;
+
         public ReceiveMessageData()
         {
             MessageId = -1;
@@ -58,6 +60,7 @@ namespace Content
             SenderId = -1;
             SentTime = new DateTime();
             Starred = false;
+            ReplyMsgId = -1;
         }
 
         /// <summary>
@@ -75,6 +78,7 @@ namespace Content
             ReplyThreadId = msgData.ReplyThreadId;
             Starred = msgData.Starred;
             Type = msgData.Type;
+            ReplyMsgId = msgData.ReplyMsgId;
         }
     }
 }

--- a/Content/Models/SendMessageData.cs
+++ b/Content/Models/SendMessageData.cs
@@ -22,11 +22,14 @@ namespace Content
         /// </summary>
         public MessageType Type;
 
+        public int ReplyMsgId;
+
         public SendMessageData()
         {
             Message = "";
             ReceiverIds = null;
             ReplyThreadId = -1;
+            ReplyMsgId = -1;
         }
     }
 }


### PR DESCRIPTION
we have added replyMsgId field in all of our datastructures to support reply to msg, just make sure that you will give valid msgId to replyMsgId i.e msgId of existed msg and thread id of it and also please note that reply feature will only support broadcast messages, so please make sure that receiverId is new int[]{} for reply and also of msg replied to. Dashboard will not be affected by this change.